### PR TITLE
feat: undo and redo in the card editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Undo and redo in the card editor, on ⌘Z / ⌘⇧Z and as buttons in the card
+  header — in the "⋯" menu on a phone, where the header has no room for them.
+  It covers typing as well as everything the editor writes for you: slash
+  commands, `[[` references, list continuation, cut line, pasted files, and
+  ticking a task box in the preview. The caret goes back where it was, typing
+  is grouped into whole words and lines rather than single keystrokes, and each
+  card keeps its own history for as long as it is open.
+
 - Folder sync on desktop: a board mirrors to a folder.
 - Attachments mirror into `_files`.
 - Deleted cards land in `_trash`.

--- a/apps/client/src/components/card-panel/card-body-editor.tsx
+++ b/apps/client/src/components/card-panel/card-body-editor.tsx
@@ -9,6 +9,8 @@ import { useUploads } from "@/providers/attachment-upload/attachment-upload-cont
 import { CardMarkdown } from "../card/card-markdown"
 import { Markdown } from "@doska/ui-kit"
 import { MarkdownTextarea } from "../markdown"
+import type { EditorFieldProps } from "./use-card-history"
+import type { EditSource } from "./text-history"
 
 const PREVIEW_MARKERS = [cut]
 
@@ -16,7 +18,9 @@ interface IProps {
   cardId: string
   body: string
   isPreview: boolean
-  onChangeBody: (value: string) => void
+  onChangeBody: (value: string, source: EditSource) => void
+  /** Wires the body into the card's shared undo history. */
+  editorProps: EditorFieldProps
   /** Non-scrolling pane element the mobile slash button anchors to. */
   overlayContainer?: HTMLElement | null
 }
@@ -27,6 +31,7 @@ export function CardBodyEditor({
   body,
   isPreview,
   onChangeBody,
+  editorProps,
   overlayContainer,
 }: IProps) {
   const { id: deckId } = useDeck()
@@ -51,11 +56,12 @@ export function CardBodyEditor({
   return (
     <CardMarkdown cardId={cardId}>
       <MarkdownTextarea
+        {...editorProps}
         renderPreview={Markdown}
         value={body}
-        onChange={(e) => onChangeBody(e.target.value)}
-        onChangeValue={onChangeBody}
-        onToggleTask={onChangeBody}
+        onChange={(e) => onChangeBody(e.target.value, "typing")}
+        onChangeValue={(value) => onChangeBody(value, "command")}
+        onToggleTask={(value) => onChangeBody(value, "command")}
         slashMenu
         highlight
         slashCommands={slashCommands}

--- a/apps/client/src/components/card-panel/card-editor.tsx
+++ b/apps/client/src/components/card-panel/card-editor.tsx
@@ -1,4 +1,4 @@
-import { Markdown, cn } from "@doska/ui-kit"
+import { Markdown, cn, useIsMobile } from "@doska/ui-kit"
 import { useState } from "react"
 import { MarkdownTextarea } from "../markdown"
 import { CardPaneLayout } from "./card-pane-layout"
@@ -10,14 +10,22 @@ import { CardAttachments } from "../card/attachments/card-attachments"
 import { AddAttachmentButton } from "../card/attachments/add-attachment-button"
 import { AttachmentDropZone } from "../card/attachments/attachment-drop-zone"
 import { AttachmentUploadProvider } from "@/providers/attachment-upload/attachment-upload-provider"
+import { UndoRedoButtons, type UndoRedoProps } from "./undo-redo-buttons"
+import type { EditorFieldProps } from "./use-card-history"
+import type { EditSource } from "./text-history"
 
 interface IProps {
   cardId: string
   title: string
   body: string
   isPreview: boolean
+  /** Wires each field into the card's shared undo history. */
+  titleProps: EditorFieldProps
+  bodyProps: EditorFieldProps
+  /** Drives the visible undo/redo controls. */
+  history: UndoRedoProps
   onChangeTitle: (value: string) => void
-  onChangeBody: (value: string) => void
+  onChangeBody: (value: string, source: EditSource) => void
   onTogglePreview: () => void
   /** Fired by clicking the read-only preview. */
   onEdit: () => void
@@ -43,6 +51,9 @@ export function CardEditor({
   title,
   body,
   isPreview,
+  titleProps,
+  bodyProps,
+  history,
   onChangeTitle,
   onChangeBody,
   onTogglePreview,
@@ -53,6 +64,9 @@ export function CardEditor({
 }: IProps) {
   // State, not a ref: the slash button renders into this node once it mounts.
   const [overlay, setOverlay] = useState<HTMLDivElement | null>(null)
+  // A phone's header is already clipping the card's meta to fit what it has;
+  // two more buttons go in the "⋯" menu instead.
+  const isMobile = useIsMobile()
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -68,11 +82,17 @@ export function CardEditor({
                   isPreview={isPreview}
                   onClose={onClose}
                   onTogglePreivew={onTogglePreview}
-                  actions={<AddAttachmentButton />}
+                  actions={
+                    <>
+                      {!isMobile && <UndoRedoButtons {...history} />}
+                      <AddAttachmentButton />
+                    </>
+                  }
                   menu={
                     <CardPanelMenu
                       cardId={cardId}
                       isPreview={isPreview}
+                      history={isMobile ? history : undefined}
                       onEdit={onEdit}
                       onReveal={onReveal}
                       onDelete={onDelete}
@@ -98,6 +118,7 @@ export function CardEditor({
               }
               title={
                 <MarkdownTextarea
+                  {...titleProps}
                   renderPreview={Markdown}
                   autoFocus
                   value={title}
@@ -115,6 +136,7 @@ export function CardEditor({
                   cardId={cardId}
                   body={body}
                   isPreview={isPreview}
+                  editorProps={bodyProps}
                   onChangeBody={onChangeBody}
                   overlayContainer={overlay}
                 />

--- a/apps/client/src/components/card-panel/card-pane.tsx
+++ b/apps/client/src/components/card-panel/card-pane.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react"
 import { CardEditor } from "./card-editor"
+import { useCardHistory } from "./use-card-history"
+import type { EditSource } from "./text-history"
 import type { Card } from "@doska/core/types"
 
 /** Backs the textareas only: round-tripping each keystroke would lag the caret. */
@@ -26,7 +28,23 @@ export function CardPane({
   const [draft, setDraft] = useState<Draft>({})
   const [isPreview, setPreview] = useState(() => Boolean(content.body.trim()))
 
-  const edit = (patch: Draft) => {
+  // Untouched fields still follow the card, so these are what is on screen.
+  const title = draft.title ?? content.title
+  const body = draft.body ?? content.body
+
+  const history = useCardHistory({
+    state: { title, body },
+    onRestore: (patch) => {
+      setDraft((d) => ({ ...d, ...patch }))
+      // A step always changes something, but never queue an empty write on the
+      // strength of that.
+      if (patch.title !== undefined || patch.body !== undefined)
+        onQueue(cardId, patch)
+    },
+  })
+
+  const edit = (patch: Draft, source: EditSource) => {
+    history.record({ title, body, ...patch }, source)
     setDraft((d) => ({ ...d, ...patch }))
     onQueue(cardId, patch)
   }
@@ -34,12 +52,24 @@ export function CardPane({
   return (
     <CardEditor
       cardId={cardId}
-      title={draft.title ?? content.title}
-      body={draft.body ?? content.body}
+      title={title}
+      body={body}
       isPreview={isPreview}
-      onChangeTitle={(title) => edit({ title })}
-      onChangeBody={(body) => edit({ body })}
-      onTogglePreview={() => setPreview(!isPreview)}
+      titleProps={history.fieldProps("title")}
+      bodyProps={history.fieldProps("body")}
+      history={{
+        canUndo: history.canUndo,
+        canRedo: history.canRedo,
+        onUndo: history.undo,
+        onRedo: history.redo,
+      }}
+      onChangeTitle={(title) => edit({ title }, "typing")}
+      onChangeBody={(body, source) => edit({ body }, source)}
+      onTogglePreview={() => {
+        // Switching how the card is shown ends the run of typing behind it.
+        history.breakGroup()
+        setPreview(!isPreview)
+      }}
       onEdit={() => setPreview(false)}
       onClose={onClose}
       onDelete={onDelete}

--- a/apps/client/src/components/card-panel/card-panel-menu.tsx
+++ b/apps/client/src/components/card-panel/card-panel-menu.tsx
@@ -7,16 +7,26 @@ import {
   MenuTrigger,
   type MenuActions,
 } from "@doska/ui-kit"
-import { LocateFixed, MoreHorizontal, Pencil, Trash2 } from "lucide-react"
+import {
+  LocateFixed,
+  MoreHorizontal,
+  Pencil,
+  Redo2,
+  Trash2,
+  Undo2,
+} from "lucide-react"
 import { useRef } from "react"
 import { CopyIdItem } from "../card/menu/copy-id-item"
 import { DeadlineSub } from "../card/menu/deadline-sub"
 import { MoveToColumnSub } from "../card/menu/move-to-column-sub"
 import { PrioritySub } from "../card/menu/priority-sub"
+import type { UndoRedoProps } from "./undo-redo-buttons"
 
 interface IProps {
   cardId: string
   isPreview: boolean
+  /** Undo/redo, given only where the header has no room for their buttons. */
+  history?: UndoRedoProps
   onEdit: () => void
   onReveal: () => void
   onDelete: () => void
@@ -30,6 +40,7 @@ interface IProps {
 export function CardPanelMenu({
   cardId,
   isPreview,
+  history,
   onEdit,
   onReveal,
   onDelete,
@@ -46,6 +57,19 @@ export function CardPanelMenu({
         <MoreHorizontal />
       </MenuTrigger>
       <MenuContent align="end">
+        {history && (
+          <>
+            <MenuItem onClick={history.onUndo} disabled={!history.canUndo}>
+              <Undo2 />
+              Undo
+            </MenuItem>
+            <MenuItem onClick={history.onRedo} disabled={!history.canRedo}>
+              <Redo2 />
+              Redo
+            </MenuItem>
+            <MenuSeparator />
+          </>
+        )}
         {isPreview && (
           <MenuItem onClick={onEdit}>
             <Pencil />

--- a/apps/client/src/components/card-panel/text-history.test.ts
+++ b/apps/client/src/components/card-panel/text-history.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, it } from "vitest"
+import {
+  breakGroup,
+  canRedo,
+  canUndo,
+  createHistory,
+  current,
+  diff,
+  record,
+  redo,
+  undo,
+  type Field,
+  type History,
+  type Snapshot,
+} from "./text-history"
+
+const snap = (title: string, body: string): Snapshot => ({ title, body })
+
+function makeClock(start = 0) {
+  let t = start
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms
+      return t
+    },
+  }
+}
+
+type Clock = ReturnType<typeof makeClock>
+
+/** Simulates typing `text` into `field` one char at a time at caret `at`,
+ * like a real user, advancing the clock by `stepMs` between keystrokes. */
+function typeText(
+  h: History,
+  state: Snapshot,
+  field: Field,
+  text: string,
+  at: number,
+  clock: Clock,
+  stepMs = 100
+): Snapshot {
+  let pos = at
+  for (const ch of text) {
+    const prev = state
+    const value = state[field].slice(0, pos) + ch + state[field].slice(pos)
+    const next: Snapshot = { ...state, [field]: value }
+    record(h, prev, next, "typing", clock.advance(stepMs))
+    state = next
+    pos += 1
+  }
+  return state
+}
+
+/** Simulates pressing backspace `count` times starting with the caret at
+ * `at`, removing one char to the left each time. */
+function backspaceText(
+  h: History,
+  state: Snapshot,
+  field: Field,
+  count: number,
+  at: number,
+  clock: Clock,
+  stepMs = 100
+): Snapshot {
+  let pos = at
+  for (let i = 0; i < count; i++) {
+    const prev = state
+    const value = state[field].slice(0, pos - 1) + state[field].slice(pos)
+    const next: Snapshot = { ...state, [field]: value }
+    record(h, prev, next, "typing", clock.advance(stepMs))
+    state = next
+    pos -= 1
+  }
+  return state
+}
+
+describe("diff", () => {
+  it("pure insert", () => {
+    expect(diff("hello", "hello world")).toEqual({
+      start: 5,
+      removed: 0,
+      inserted: 6,
+    })
+  })
+
+  it("pure delete", () => {
+    expect(diff("hello world", "hello")).toEqual({
+      start: 5,
+      removed: 6,
+      inserted: 0,
+    })
+  })
+
+  it("replacement", () => {
+    expect(diff("cat", "dog")).toEqual({ start: 0, removed: 3, inserted: 3 })
+  })
+
+  it("identical strings", () => {
+    const d = diff("same", "same")
+    expect(d.removed).toBe(0)
+    expect(d.inserted).toBe(0)
+    expect(d.start).toBe(4)
+  })
+
+  it("insert at start", () => {
+    expect(diff("world", "hello world")).toEqual({
+      start: 0,
+      removed: 0,
+      inserted: 6,
+    })
+  })
+
+  it("insert at end", () => {
+    expect(diff("hello", "hello world")).toEqual({
+      start: 5,
+      removed: 0,
+      inserted: 6,
+    })
+  })
+
+  it("clamps so prefix and suffix don't overlap", () => {
+    // Naive unclamped suffix scanning would walk "aa" -> "aaa" as removed: -2.
+    expect(diff("aa", "aaa")).toEqual({ start: 2, removed: 0, inserted: 1 })
+  })
+})
+
+describe("record: typing coalesces into words", () => {
+  it("typing 'hello' one char at a time is one undo step", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    typeText(h, snap("", ""), "body", "hello", 0, clock)
+
+    expect(current(h)?.state.body).toBe("hello")
+    expect(canUndo(h)).toBe(true)
+
+    const back = undo(h)
+    expect(back?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("typing 'hello world' undoes 'world' then 'hello ' (trailing space absorbed)", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    typeText(h, snap("", ""), "body", "hello world", 0, clock)
+
+    expect(current(h)?.state.body).toBe("hello world")
+
+    const step1 = undo(h)
+    expect(step1?.state.body).toBe("hello ")
+
+    const step2 = undo(h)
+    expect(step2?.state.body).toBe("")
+
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it('"don\'t" stays one step (apostrophe is a word char)', () => {
+    const h = createHistory()
+    const clock = makeClock()
+    typeText(h, snap("", ""), "body", "don't", 0, clock)
+
+    expect(current(h)?.state.body).toBe("don't")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("'foo(bar)' stays one step (punctuation is a word char)", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    typeText(h, snap("", ""), "body", "foo(bar)", 0, clock)
+
+    expect(current(h)?.state.body).toBe("foo(bar)")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("a newline is always its own step, joining neither neighbor", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+    state = typeText(h, state, "body", "ab", 0, clock)
+    state = typeText(h, state, "body", "\n", 2, clock)
+    typeText(h, state, "body", "cd", 3, clock)
+
+    expect(current(h)?.state.body).toBe("ab\ncd")
+    expect(undo(h)?.state.body).toBe("ab\n")
+    expect(undo(h)?.state.body).toBe("ab")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("backspacing 'hello world' undoes the mirror-image groups", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    // First record seeds the base with the full string.
+    backspaceText(h, snap("", "hello world"), "body", 11, 11, clock)
+
+    expect(current(h)?.state.body).toBe("")
+    const step1 = undo(h)
+    const step2 = undo(h)
+
+    expect(canUndo(h)).toBe(false)
+    // Backspace runs right-to-left, so the first group ate "world" and then
+    // absorbed the space *before* it — the deleted runs are " world" and
+    // "hello". Undo is LIFO, so it gives back the word deleted last first.
+    expect(step1?.state.body).toBe("hello")
+    expect(step2?.state.body).toBe("hello world")
+  })
+
+  it("a caret jump breaks the group", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+    state = typeText(h, state, "body", "abc", 0, clock)
+    typeText(h, state, "body", "X", 0, clock)
+
+    expect(current(h)?.state.body).toBe("Xabc")
+    expect(undo(h)?.state.body).toBe("abc")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("switching from inserting to deleting breaks the group", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    const state = typeText(h, snap("", ""), "body", "abc", 0, clock)
+    backspaceText(h, state, "body", 1, 3, clock)
+
+    expect(current(h)?.state.body).toBe("ab")
+    expect(undo(h)?.state.body).toBe("abc")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("a replacement is always its own step", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = typeText(h, snap("", ""), "title", "cat", 0, clock)
+
+    const prev = state
+    state = { ...state, title: "dog" }
+    record(h, prev, state, "typing", clock.advance(100))
+
+    expect(current(h)?.state.title).toBe("dog")
+    expect(undo(h)?.state.title).toBe("cat")
+    expect(undo(h)?.state.title).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("a command edit never absorbs typing before or after it", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = typeText(h, snap("", ""), "body", "ab", 0, clock)
+
+    const prev = state
+    state = { ...state, body: "ab[[link]]" }
+    record(h, prev, state, "command", clock.advance(100))
+
+    typeText(h, state, "body", "cd", state.body.length, clock)
+
+    expect(current(h)?.state.body).toBe("ab[[link]]cd")
+    expect(undo(h)?.state.body).toBe("ab[[link]]")
+    expect(undo(h)?.state.body).toBe("ab")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("elapsed time is a fallback: a >IDLE_MS gap splits an otherwise-adjacent run", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+
+    const prev1 = state
+    state = { ...state, body: "a" }
+    record(h, prev1, state, "typing", clock.advance(100))
+
+    const prev2 = state
+    state = { ...state, body: "ab" }
+    record(h, prev2, state, "typing", clock.advance(6000))
+
+    expect(current(h)?.state.body).toBe("ab")
+    expect(undo(h)?.state.body).toBe("a")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+
+  it("a gap under IDLE_MS does not split an adjacent run", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+
+    const prev1 = state
+    state = { ...state, body: "a" }
+    record(h, prev1, state, "typing", clock.advance(100))
+
+    const prev2 = state
+    state = { ...state, body: "ab" }
+    record(h, prev2, state, "typing", clock.advance(4000))
+
+    expect(current(h)?.state.body).toBe("ab")
+    expect(undo(h)?.state.body).toBe("")
+    expect(canUndo(h)).toBe(false)
+  })
+})
+
+describe("breakGroup", () => {
+  it("forces the next edit to start a fresh step", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    const state = typeText(h, snap("", ""), "body", "ab", 0, clock)
+
+    breakGroup(h)
+    typeText(h, state, "body", "c", 2, clock)
+
+    expect(current(h)?.state.body).toBe("abc")
+    expect(undo(h)?.state.body).toBe("ab")
+    expect(undo(h)?.state.body).toBe("")
+  })
+})
+
+describe("redo", () => {
+  it("undoing then recording truncates the redo branch", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+    state = typeText(h, state, "body", "a", 0, clock)
+    breakGroup(h)
+    state = typeText(h, state, "body", "b", 1, clock)
+    breakGroup(h)
+    typeText(h, state, "body", "c", 2, clock)
+
+    expect(current(h)?.state.body).toBe("abc")
+    undo(h)
+    undo(h)
+    undo(h)
+    expect(current(h)?.state.body).toBe("")
+    expect(canRedo(h)).toBe(true)
+
+    const prev = current(h)!.state
+    const next = { ...prev, body: "z" }
+    record(h, prev, next, "typing", clock.advance(100))
+
+    expect(current(h)?.state.body).toBe("z")
+    expect(canRedo(h)).toBe(false)
+    expect(redo(h)).toBe(null)
+  })
+})
+
+describe("lazy base", () => {
+  it("the first record seeds the stack with the pre-edit state", () => {
+    const h = createHistory()
+    expect(current(h)).toBe(null)
+
+    const prev = snap("hello", "world")
+    const next = snap("hello!", "world")
+    record(h, prev, next, "typing", 0)
+
+    expect(h.entries.length).toBe(2)
+    expect(canUndo(h)).toBe(true)
+    const back = undo(h)
+    expect(back?.state).toEqual(prev)
+    expect(canUndo(h)).toBe(false)
+  })
+})
+
+describe("no-op", () => {
+  it("leaves the history untouched when nothing changed", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    const state = typeText(h, snap("", ""), "body", "a", 0, clock)
+
+    const before = JSON.stringify(h)
+    record(h, state, { ...state }, "typing", clock.advance(100))
+    record(h, state, { ...state }, "command", clock.advance(100))
+
+    expect(JSON.stringify(h)).toBe(before)
+  })
+})
+
+describe("both fields share one stack", () => {
+  it("undo walks back across fields in order, preserving the untouched one", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+    state = typeText(h, state, "title", "abc", 0, clock)
+    breakGroup(h)
+    typeText(h, state, "body", "xyz", 0, clock)
+
+    expect(current(h)?.state).toEqual(snap("abc", "xyz"))
+
+    const step1 = undo(h)
+    expect(step1?.state).toEqual(snap("abc", ""))
+
+    const step2 = undo(h)
+    expect(step2?.state).toEqual(snap("", ""))
+
+    expect(canUndo(h)).toBe(false)
+  })
+})
+
+describe("trimming", () => {
+  it("keeps index valid and current() the newest state past MAX_ENTRIES", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("seed", "")
+
+    record(h, snap("", ""), state, "command", clock.advance(100))
+    for (let i = 0; i < 600; i++) {
+      const prev = state
+      state = { ...state, title: `seed-${i}` }
+      record(h, prev, state, "command", clock.advance(100))
+    }
+
+    expect(h.entries.length).toBeLessThanOrEqual(500)
+    expect(h.index).toBeGreaterThanOrEqual(0)
+    expect(h.index).toBeLessThan(h.entries.length)
+    expect(h.index).toBe(h.entries.length - 1)
+    expect(current(h)?.state.title).toBe("seed-599")
+  })
+
+  // The budget has to stay honest as entries come and go, or the char cap
+  // would eventually trim every push down to a single entry.
+  it("the char budget tracks only the entries still retained", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    let state = snap("", "")
+
+    for (let i = 0; i < 600; i++) {
+      const prev = state
+      state = { ...state, body: `body-${i}` }
+      record(h, prev, state, "command", clock.advance(100))
+    }
+    // Undo a way back, then edit, so a redo branch is discarded too.
+    undo(h)
+    undo(h)
+    const prev = current(h)!.state
+    record(
+      h,
+      prev,
+      { ...prev, body: "branched" },
+      "command",
+      clock.advance(100)
+    )
+
+    const retained = h.entries.reduce((sum, e) => sum + e.cost, 0)
+    expect(h.chars).toBe(retained)
+  })
+})
+
+describe("boundaries", () => {
+  it("undo at the base returns null", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    typeText(h, snap("", ""), "body", "a", 0, clock)
+
+    undo(h)
+    expect(undo(h)).toBe(null)
+  })
+
+  it("redo at the tip returns null", () => {
+    const h = createHistory()
+    const clock = makeClock()
+    typeText(h, snap("", ""), "body", "a", 0, clock)
+
+    expect(redo(h)).toBe(null)
+  })
+
+  it("undo and redo on a never-recorded history return null", () => {
+    const h = createHistory()
+    expect(undo(h)).toBe(null)
+    expect(redo(h)).toBe(null)
+    expect(current(h)).toBe(null)
+  })
+})

--- a/apps/client/src/components/card-panel/text-history.ts
+++ b/apps/client/src/components/card-panel/text-history.ts
@@ -1,0 +1,272 @@
+// Undo/redo history for one card's editing session. A card has two text
+// fields, title and body, and they share one stack: entries are full
+// snapshots of both, but a snapshot shares the untouched field's string by
+// reference, so an entry only ever costs one string copy.
+
+export type Field = "title" | "body"
+export type EditSource = "typing" | "command"
+
+/** Both fields of a card, as they stood at one point in the session. */
+export interface Snapshot {
+  title: string
+  body: string
+}
+
+/** Where the caret sat while a snapshot was current. */
+export interface Sel {
+  field: Field
+  start: number
+  end: number
+}
+
+export interface Entry {
+  state: Snapshot
+  /** Settled selection for this state, or null when no field had focus. */
+  sel: Sel | null
+  /** Chars this entry changed. Internal bookkeeping for the trim budget. */
+  cost: number
+}
+
+/** A contiguous run of typing that undo takes back in one step. */
+interface Group {
+  field: Field
+  kind: "insert" | "delete"
+  /** Where the next change must touch to continue this group. */
+  caret: number
+  cls: "word" | "space"
+  at: number
+  size: number
+}
+
+export interface History {
+  entries: Entry[]
+  /** `entries[index]` is current; everything after it is the redo branch. */
+  index: number
+  group: Group | null
+  /** Sum of `cost` over the retained entries, for the trim budget. A proxy
+   * for memory, not a true byte count: snapshots share unchanged strings. */
+  chars: number
+}
+
+export interface Change {
+  start: number
+  removed: number
+  inserted: number
+}
+
+// Grouping boundaries are primary; these are fallback safety nets only, so
+// they're generous. Pausing mid-word to think must not split the word, and
+// real sessions never come close to the size caps below.
+const IDLE_MS = 5000
+const MAX_GROUP = 1000
+const MAX_ENTRIES = 500
+const MAX_CHARS = 2_000_000
+
+/**
+ * Common-prefix / common-suffix scan between two strings. `start` is the
+ * length of the shared prefix; `removed`/`inserted` are what's left of `a`
+ * and `b` once the shared prefix and suffix are stripped.
+ */
+export function diff(a: string, b: string): Change {
+  const max = Math.min(a.length, b.length)
+  let start = 0
+  while (start < max && a[start] === b[start]) start++
+
+  // Clamp so the suffix scan can't walk back over the prefix it just found —
+  // otherwise "aa" -> "aaa" would double-count the shared "a"s.
+  const maxSuffix = max - start
+  let end = 0
+  while (end < maxSuffix && a[a.length - 1 - end] === b[b.length - 1 - end]) {
+    end++
+  }
+
+  return {
+    start,
+    removed: a.length - start - end,
+    inserted: b.length - start - end,
+  }
+}
+
+/**
+ * Classifies a run of changed text so an insert/delete knows what group it
+ * may join. Punctuation counts as a word char — `don't` and `foo(bar)` are
+ * one run by design — and any newline forces its own step.
+ */
+function runClass(text: string): "word" | "space" | null {
+  if (/[\n\r]/.test(text)) return null
+  let sawWord = false
+  let sawSpace = false
+  for (const ch of text) {
+    if (ch === " " || ch === "\t") sawSpace = true
+    else sawWord = true
+  }
+  if (sawWord && sawSpace) return null
+  if (sawWord) return "word"
+  if (sawSpace) return "space"
+  return null
+}
+
+function fieldChangeLen(a: string, b: string): number {
+  const d = diff(a, b)
+  return d.removed + d.inserted
+}
+
+export function createHistory(): History {
+  return { entries: [], index: -1, group: null, chars: 0 }
+}
+
+/** Pushes a new entry onto the current branch, dropping any redo branch. */
+function pushEntry(
+  h: History,
+  next: Snapshot,
+  changedLength: number,
+  group: Group | null
+): void {
+  // Dropping the redo branch hands its budget back.
+  for (let i = h.index + 1; i < h.entries.length; i++)
+    h.chars -= h.entries[i].cost
+  h.entries.length = h.index + 1
+  h.entries.push({ state: next, sel: null, cost: changedLength })
+  h.index++
+  h.group = group
+  h.chars += changedLength
+
+  // Both caps slide a window over the session rather than cutting it off: an
+  // entry hands its budget back as it leaves. The length floor is only for the
+  // degenerate case of a single change bigger than the whole budget.
+  while (
+    (h.entries.length > MAX_ENTRIES || h.chars > MAX_CHARS) &&
+    h.entries.length > 1
+  ) {
+    const dropped = h.entries.shift()
+    if (dropped) h.chars -= dropped.cost
+    h.index = Math.max(0, h.index - 1)
+  }
+}
+
+/**
+ * Records prev -> next as a step, coalescing a run of typing into the
+ * current entry when it continues the same word/space run at the same
+ * caret. `now` is passed in so callers (and tests) control time.
+ */
+export function record(
+  h: History,
+  prev: Snapshot,
+  next: Snapshot,
+  source: EditSource,
+  now: number
+): void {
+  // Lazy base: the stack starts empty, so the first record seeds it with the
+  // exact pre-edit state rather than something captured at mount.
+  if (h.entries.length === 0) {
+    h.entries.push({ state: prev, sel: null, cost: 0 })
+    h.index = 0
+  }
+
+  if (next.title === prev.title && next.body === prev.body) return
+
+  const titleChanged = next.title !== prev.title
+  const bodyChanged = next.body !== prev.body
+
+  // A command edit, or a change that touched both fields at once, never
+  // coalesces.
+  if (source === "command" || (titleChanged && bodyChanged)) {
+    const len =
+      (titleChanged ? fieldChangeLen(prev.title, next.title) : 0) +
+      (bodyChanged ? fieldChangeLen(prev.body, next.body) : 0)
+    pushEntry(h, next, len, null)
+    return
+  }
+
+  const field: Field = titleChanged ? "title" : "body"
+  const ch = diff(prev[field], next[field])
+
+  const kind: "insert" | "delete" | "replace" =
+    ch.inserted > 0 && ch.removed === 0
+      ? "insert"
+      : ch.removed > 0 && ch.inserted === 0
+        ? "delete"
+        : "replace"
+
+  // A replacement (a selection overtyped) can never coalesce.
+  if (kind === "replace") {
+    pushEntry(h, next, ch.removed + ch.inserted, null)
+    return
+  }
+
+  const changedText =
+    kind === "insert"
+      ? next[field].slice(ch.start, ch.start + ch.inserted)
+      : prev[field].slice(ch.start, ch.start + ch.removed)
+  const cls = runClass(changedText)
+  const changedLength = changedText.length
+  const caret = kind === "insert" ? ch.start + ch.inserted : ch.start
+
+  const g = h.group
+  if (
+    g !== null &&
+    cls !== null &&
+    g.field === field &&
+    g.kind === kind &&
+    // Adjacency: an insert must land where the group left off; a delete may
+    // be a backspace eating leftward from the caret or a forward delete
+    // eating rightward.
+    (kind === "insert"
+      ? ch.start === g.caret
+      : ch.start + ch.removed === g.caret || ch.start === g.caret) &&
+    // Whitespace is absorbed into the word run it follows; space -> word
+    // always breaks, which is what makes undo take back whole words.
+    (cls === g.cls || (g.cls === "word" && cls === "space")) &&
+    now - g.at <= IDLE_MS &&
+    g.size + changedLength <= MAX_GROUP
+  ) {
+    h.entries[h.index].state = next
+    h.entries[h.index].cost += changedLength
+    h.chars += changedLength
+    g.cls = cls
+    g.caret = caret
+    g.at = now
+    g.size += changedLength
+    return
+  }
+
+  // Nothing can join a step that was never a plain typed run.
+  pushEntry(
+    h,
+    next,
+    changedLength,
+    cls === null
+      ? null
+      : { field, kind, caret, cls, at: now, size: changedLength }
+  )
+}
+
+export function undo(h: History): Entry | null {
+  if (h.index <= 0) return null
+  h.group = null
+  h.index--
+  return h.entries[h.index]
+}
+
+export function redo(h: History): Entry | null {
+  if (h.index >= h.entries.length - 1) return null
+  h.group = null
+  h.index++
+  return h.entries[h.index]
+}
+
+export function breakGroup(h: History): void {
+  h.group = null
+}
+
+export function canUndo(h: History): boolean {
+  return h.index > 0
+}
+
+export function canRedo(h: History): boolean {
+  return h.index < h.entries.length - 1
+}
+
+export function current(h: History): Entry | null {
+  return h.entries[h.index] ?? null
+}

--- a/apps/client/src/components/card-panel/undo-redo-buttons.tsx
+++ b/apps/client/src/components/card-panel/undo-redo-buttons.tsx
@@ -1,0 +1,63 @@
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@doska/ui-kit"
+import { Redo2, Undo2 } from "lucide-react"
+
+/** The open card's history, as the controls that drive it need it. */
+export interface UndoRedoProps {
+  canUndo: boolean
+  canRedo: boolean
+  onUndo: () => void
+  onRedo: () => void
+}
+
+/**
+ * Undo/redo for the open card. The shortcuts only reach a focused textarea, so
+ * these are the only way back from an edit made in the preview — ticking a task
+ * box, say — as well as the visible reminder that the card has a history at all.
+ */
+export function UndoRedoButtons({
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+}: UndoRedoProps) {
+  const undo = (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label="Undo"
+      disabled={!canUndo}
+      // Don't take focus: blurring the editor would end the run of typing the
+      // click is about to take back, and lose the caret with it.
+      onPointerDown={(e) => e.preventDefault()}
+      onClick={onUndo}
+    >
+      <Undo2 />
+    </Button>
+  )
+
+  const redo = (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label="Redo"
+      disabled={!canRedo}
+      onPointerDown={(e) => e.preventDefault()}
+      onClick={onRedo}
+    >
+      <Redo2 />
+    </Button>
+  )
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger render={undo} />
+        <TooltipContent side="bottom">Undo</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger render={redo} />
+        <TooltipContent side="bottom">Redo</TooltipContent>
+      </Tooltip>
+    </>
+  )
+}

--- a/apps/client/src/components/card-panel/use-card-history.ts
+++ b/apps/client/src/components/card-panel/use-card-history.ts
@@ -1,0 +1,214 @@
+import { useLayoutEffect, useMemo, useRef, useState } from "react"
+import {
+  breakGroup,
+  canRedo,
+  canUndo,
+  createHistory,
+  current,
+  diff,
+  record,
+  redo,
+  undo,
+  type EditSource,
+  type Entry,
+  type Field,
+  type Sel,
+  type Snapshot,
+} from "./text-history"
+
+const FIELDS = ["title", "body"] as const
+
+type FieldRefs = Record<Field, React.RefObject<HTMLTextAreaElement | null>>
+
+/** What a field's textarea needs to take part in the card's history. */
+export interface EditorFieldProps {
+  inputRef: React.RefObject<HTMLTextAreaElement | null>
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
+  onBlur: () => void
+  onCompositionStart: () => void
+  onCompositionEnd: (e: React.CompositionEvent<HTMLTextAreaElement>) => void
+}
+
+interface Options {
+  /** What is on screen right now — the `prev` the next edit is recorded from. */
+  state: Snapshot
+  /** Puts the fields a step changed back on screen and queues them for saving. */
+  onRestore: (patch: Partial<Snapshot>) => void
+}
+
+/** The selection in whichever field has focus, or null when none has it. */
+function readSel(refs: FieldRefs): Sel | null {
+  for (const field of FIELDS) {
+    const el = refs[field].current
+    if (el && document.activeElement === el)
+      return { field, start: el.selectionStart, end: el.selectionEnd }
+  }
+  return null
+}
+
+/**
+ * Undo/redo for one card's editing session. Title and body share a single
+ * stack, and the hook is mounted with the card, so a stack can neither outlive
+ * its card nor reach another one.
+ */
+export function useCardHistory({ state, onRestore }: Options) {
+  // Held in state, not a ref, so it can be read during render: it is created
+  // once and then mutated in place, never replaced.
+  const [history] = useState(createHistory)
+
+  const titleRef = useRef<HTMLTextAreaElement>(null)
+  const bodyRef = useRef<HTMLTextAreaElement>(null)
+  const refs = useMemo<FieldRefs>(
+    () => ({ title: titleRef, body: bodyRef }),
+    [titleRef, bodyRef]
+  )
+
+  const [undoable, setUndoable] = useState(false)
+  const [redoable, setRedoable] = useState(false)
+  const sync = () => {
+    setUndoable(canUndo(history))
+    setRedoable(canRedo(history))
+  }
+
+  /** Selection to put back once a restored snapshot has rendered. */
+  const pending = useRef<Sel | null>(null)
+  /** The snapshot from before an IME composition; null when not composing. */
+  const composing = useRef<Snapshot | null>(null)
+
+  /**
+   * Applies a selection an undo queued, then records the settled selection for
+   * whatever entry is now current. Ordering is the point: child effects run
+   * before a parent's, so by the time this runs the hooks that own the textarea
+   * — the slash and wikilink menus, paste, list continuation — have already put
+   * their own caret back. What it reads is therefore the caret an insertion
+   * meant, not the one that preceded it.
+   */
+  useLayoutEffect(() => {
+    if (composing.current) return
+
+    const sel = pending.current
+    if (sel) {
+      pending.current = null
+      const el = refs[sel.field].current
+      if (el) {
+        el.focus()
+        el.setSelectionRange(sel.start, sel.end)
+      }
+    }
+
+    const entry = current(history)
+    if (entry) entry.sel = readSel(refs)
+  }, [state.title, state.body, history, refs])
+
+  /**
+   * Where to put the caret when the step's own recorded selection is no use —
+   * it belongs to a field this step did not touch, or the entry never had one.
+   * The end of the changed run in the restored text is where the edit was, and
+   * so where the caret belongs.
+   */
+  const caretAtChange = (field: Field, from: Snapshot, to: Snapshot): Sel => {
+    const d = diff(from[field], to[field])
+    const at = d.start + d.inserted
+    return { field, start: at, end: at }
+  }
+
+  /**
+   * Walks the stack one step and puts back only what that step changed.
+   * Entries snapshot both fields, but restoring both would roll back whatever
+   * had meanwhile arrived in the field the step never touched — a remote
+   * rename landing on the title while the body is being typed, say, which
+   * undo would otherwise revert and then save.
+   */
+  const step = (move: () => Entry | null) => {
+    const from = current(history)
+    const to = move()
+    if (!from || !to) return
+
+    const patch: Partial<Snapshot> = {}
+    if (to.state.title !== from.state.title) patch.title = to.state.title
+    if (to.state.body !== from.state.body) patch.body = to.state.body
+
+    // Prefer the caret the entry recorded — for a slash insert that is the
+    // spot the snippet meant, mid-snippet and all. It is only usable when it
+    // belongs to a field this step actually restored.
+    const changed = (Object.keys(patch) as Field[])[0]
+    pending.current =
+      to.sel && patch[to.sel.field] !== undefined
+        ? to.sel
+        : changed
+          ? caretAtChange(changed, from.state, to.state)
+          : null
+
+    onRestore(patch)
+    sync()
+  }
+
+  /**
+   * Records an edit. `source` is "typing" for keystrokes and "command" for
+   * everything the app writes itself — a slash insert, a wikilink, a pasted
+   * file, a task toggle — which never joins a run of typing.
+   *
+   * `state` is this render's, which is what every path here edits from: each
+   * one changes a single field once per event. A future path that wrote both
+   * fields in one tick would need the second write to see the first.
+   */
+  const push = (next: Snapshot, source: EditSource) => {
+    // Mid-composition states are not steps of their own; the whole composition
+    // lands as one when it ends.
+    if (composing.current) return
+    record(history, state, next, source, Date.now())
+    sync()
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Let the IME have the keystroke while it is composing.
+    if (composing.current) return
+    if (!(e.metaKey || e.ctrlKey) || e.altKey) return
+
+    const key = e.key.toLowerCase()
+    const isUndo = key === "z" && !e.shiftKey
+    const isRedo = (key === "z" && e.shiftKey) || (key === "y" && !e.shiftKey)
+    if (!isUndo && !isRedo) return
+
+    e.preventDefault()
+    step(() => (isRedo ? redo(history) : undo(history)))
+  }
+
+  const fieldProps = (field: Field): EditorFieldProps => ({
+    inputRef: refs[field],
+    onKeyDown,
+    // Coming back to a field starts a fresh step rather than extending the run
+    // that was open when focus left it.
+    onBlur: () => breakGroup(history),
+    onCompositionStart: () => {
+      composing.current = state
+    },
+    onCompositionEnd: (e) => {
+      const before = composing.current
+      composing.current = null
+      if (!before) return
+      // Read the element, not `state`: the final input event lands either side
+      // of compositionend depending on the browser, but the element holds the
+      // committed text by now either way. A cancelled composition gives back
+      // what it started with, which records as nothing.
+      record(
+        history,
+        before,
+        { ...before, [field]: e.currentTarget.value },
+        "command",
+        Date.now()
+      )
+      sync()
+    },
+  })
+
+  return {
+    fieldProps,
+    record: push,
+    breakGroup: () => breakGroup(history),
+    undo: () => step(() => undo(history)),
+    redo: () => step(() => redo(history)),
+    canUndo: undoable,
+    canRedo: redoable,
+  }
+}

--- a/apps/client/src/components/markdown/hooks/use-no-native-history.ts
+++ b/apps/client/src/components/markdown/hooks/use-no-native-history.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react"
+
+/**
+ * Turns off the browser's own undo stack for a textarea. Against a controlled
+ * React value that stack is not dependable in the first place — it restores
+ * text the app never hears about — and where the app keeps its own history the
+ * two of them fight over the same keystroke. Blocked at `beforeinput`, which
+ * catches the Edit menu, the context menu and iOS shake-to-undo as well as the
+ * shortcut.
+ *
+ * A browser that declines to fire the event leaves the native undo to land as
+ * an ordinary edit: still recorded, still undoable, never lost.
+ */
+export function useNoNativeHistory(
+  ref: React.RefObject<HTMLTextAreaElement | null>,
+  enabled = true
+) {
+  useEffect(() => {
+    const textarea = ref.current
+    if (!textarea || !enabled) return
+
+    const onBeforeInput = (e: Event) => {
+      const { inputType } = e as InputEvent
+      if (inputType === "historyUndo" || inputType === "historyRedo")
+        e.preventDefault()
+    }
+
+    textarea.addEventListener("beforeinput", onBeforeInput)
+    return () => textarea.removeEventListener("beforeinput", onBeforeInput)
+  }, [ref, enabled])
+}

--- a/apps/client/src/components/markdown/markdown-textarea.tsx
+++ b/apps/client/src/components/markdown/markdown-textarea.tsx
@@ -12,6 +12,7 @@ import { useCutLine } from "./hooks/use-cut-line"
 import { useListContinuation } from "./hooks/use-list-continuation"
 import { usePasteFiles } from "./hooks/use-paste-files"
 import { useCaretScroll } from "./hooks/use-caret-scroll"
+import { useNoNativeHistory } from "./hooks/use-no-native-history"
 import { SlashMenu } from "./slash-menu/slash-menu"
 import { WikilinkMenu } from "./wikilink-menu"
 
@@ -49,6 +50,11 @@ interface IProps extends React.ComponentProps<"textarea"> {
   onPasteFiles?: (files: File[]) => Promise<string | null>
   containerClassName?: string
   /**
+   * Lets the caller reach the textarea — to restore a caret, say. Given one,
+   * this is the ref the internal hooks use too, so there is only ever one.
+   */
+  inputRef?: React.RefObject<HTMLTextAreaElement | null>
+  /**
    * Where the mobile slash button renders. Must be a non-scrolling ancestor, or
    * the button scrolls away with the text.
    */
@@ -70,12 +76,16 @@ export function MarkdownTextarea({
   wikilinks,
   onPasteFiles,
   containerClassName,
+  inputRef,
   overlayContainer,
   ...props
 }: IProps) {
   const value = typeof props.value === "string" ? props.value : ""
   const { body } = useMarkers(value, markers, "preview")
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const ownRef = useRef<HTMLTextAreaElement>(null)
+  const textareaRef = inputRef ?? ownRef
+
+  useNoNativeHistory(textareaRef, !isPreview)
 
   useCutLine(textareaRef, {
     value,

--- a/packages/e2e/e2e/card/undo-redo.spec.ts
+++ b/packages/e2e/e2e/card/undo-redo.spec.ts
@@ -1,0 +1,463 @@
+import { test, expect, type Page } from "@playwright/test"
+import {
+  addCard,
+  card,
+  cardDisplayId,
+  cardPanel,
+  closeCard,
+  createBoard,
+  editCardBody,
+  openCard,
+  pasteInto,
+  pngDataTransfer,
+  retitleCard,
+  signIn,
+} from "../helpers"
+
+/**
+ * The card editor's own undo history. Everything here is typed and clicked the
+ * way a user would, and every assertion reads the markdown the user sees in the
+ * Notes field. Type with `pressSequentially`, not `fill`: the history groups on
+ * what was typed, and the menus are driven by the textarea's own input events.
+ *
+ * Steps are grouped on meaningful boundaries — a word, a line, a caret jump, a
+ * command — never on a timer, so nothing here has to race a clock.
+ */
+async function openNotes(page: Page) {
+  await createBoard(page)
+  await addCard(page, "To Do")
+  await card(page, "Untitled card").click()
+  const notes = page.getByPlaceholder("Notes")
+  await notes.click()
+  return notes
+}
+
+// Typechecked here but run in the page, where these exist; Node has no DOM lib.
+// Type-only, so nothing is emitted.
+declare const InputEvent: {
+  new (
+    type: string,
+    init: { inputType: string; bubbles: boolean; cancelable: boolean }
+  ): Event
+}
+declare const document: { execCommand(command: string): boolean }
+
+const UNDO = "ControlOrMeta+z"
+const REDO = "ControlOrMeta+Shift+z"
+
+test.describe("editor undo: typing", () => {
+  test("undo takes back a whole word, not one keystroke", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("hello")
+    await notes.press(UNDO)
+
+    await expect(notes).toHaveValue("")
+  })
+
+  test("undo walks back word by word and redo walks forward", async ({
+    page,
+  }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("hello world")
+
+    // The space is absorbed into the word it follows, so "world" goes first.
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("hello ")
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("")
+
+    await notes.press(REDO)
+    await expect(notes).toHaveValue("hello ")
+    await notes.press(REDO)
+    await expect(notes).toHaveValue("hello world")
+  })
+
+  test("a newline is a step of its own", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("one")
+    await notes.press("Enter")
+    await notes.pressSequentially("two")
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("one\n")
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("one")
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("")
+  })
+
+  test("the caret comes back with the text", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("hello world")
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("hello ")
+
+    // Typing continues from where the caret was left, not from the start.
+    await notes.pressSequentially("there")
+    await expect(notes).toHaveValue("hello there")
+  })
+
+  test("editing after an undo drops the redo branch", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("hello world")
+    await notes.press(UNDO)
+    await notes.pressSequentially("there")
+    await expect(notes).toHaveValue("hello there")
+
+    await notes.press(REDO)
+    await expect(notes).toHaveValue("hello there")
+  })
+})
+
+test.describe("editor undo: the app's own edits", () => {
+  test("a slash command insert is one step", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("/task")
+    await page.getByRole("button", { name: /^To-do/ }).click()
+    await expect(notes).toHaveValue("- [ ] ")
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("/task")
+
+    await notes.press(REDO)
+    await expect(notes).toHaveValue("- [ ] ")
+  })
+
+  test("an insert puts the caret back where the snippet meant it", async ({
+    page,
+  }) => {
+    const notes = await openNotes(page)
+
+    // The link snippet lands the caret between the brackets, not at the end.
+    await notes.pressSequentially("/link")
+    await page.getByRole("button", { name: /^Link/ }).click()
+    await expect(notes).toHaveValue("[](url)")
+
+    await notes.pressSequentially("here")
+    await expect(notes).toHaveValue("[here](url)")
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("[](url)")
+
+    // Back between the brackets, which is only true if the caret the insert
+    // asked for was the one recorded.
+    await notes.pressSequentially("X")
+    await expect(notes).toHaveValue("[X](url)")
+  })
+
+  test("list continuation is one step", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("- milk")
+    await notes.press("Enter")
+    await expect(notes).toHaveValue("- milk\n- ")
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("- milk")
+  })
+
+  test("a cut line comes back whole", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("one")
+    await notes.press("Enter")
+    await notes.pressSequentially("two")
+    await notes.press("ControlOrMeta+x")
+    await expect(notes).toHaveValue("one")
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("one\ntwo")
+  })
+
+  test("undo closes a slash menu left standing", async ({ page }) => {
+    const notes = await openNotes(page)
+
+    await notes.pressSequentially("abc /li")
+    const item = page.getByRole("button", { name: /^Link/ })
+    await expect(item).toBeVisible()
+
+    await notes.press(UNDO)
+
+    await expect(notes).toHaveValue("abc ")
+    // The menu re-reads the trigger off the new value and finds none.
+    await expect(item).toHaveCount(0)
+
+    await notes.pressSequentially("ok")
+    await expect(notes).toHaveValue("abc ok")
+  })
+
+  test("a task ticked in preview undoes back in the editor", async ({
+    page,
+  }) => {
+    await createBoard(page)
+    await addCard(page, "To Do")
+    await retitleCard(page, "Untitled card", "Checklist")
+    await editCardBody(page, "Checklist", "- [ ] First\n- [ ] Second")
+
+    // A card with a body opens read-only, which is where the boxes are tickable.
+    await card(page, "Checklist").click()
+    await cardPanel(page).getByRole("checkbox").first().click()
+    await expect(card(page, "Checklist")).toContainText("1/2")
+
+    await page.getByRole("button", { name: "Edit" }).click()
+    const notes = page.getByPlaceholder("Notes")
+    await notes.click()
+    await expect(notes).toHaveValue("- [x] First\n- [ ] Second")
+
+    // The stack outlives the switch between preview and editor.
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("- [ ] First\n- [ ] Second")
+  })
+})
+
+test.describe("editor undo: scope", () => {
+  test("title and body share one stack, newest first", async ({ page }) => {
+    await createBoard(page)
+    await addCard(page, "To Do")
+    await card(page, "Untitled card").click()
+
+    const title = page.getByPlaceholder("Title")
+    const notes = page.getByPlaceholder("Notes")
+
+    await title.click()
+    await title.pressSequentially("Plan")
+    await notes.click()
+    await notes.pressSequentially("draft")
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("")
+    await expect(title).toHaveValue("Plan")
+
+    // The stack is one, so the next step back is the title's — and the caret
+    // follows it there.
+    await notes.press(UNDO)
+    await expect(title).toHaveValue("")
+    await expect(title).toBeFocused()
+  })
+
+  test("each card gets its own history", async ({ page }) => {
+    await createBoard(page)
+    await addCard(page, "To Do")
+    await retitleCard(page, "Untitled card", "First")
+    await addCard(page, "To Do")
+    await retitleCard(page, "Untitled card", "Second")
+
+    await openCard(page, "First")
+    const first = page.getByPlaceholder("Notes")
+    await first.click()
+    await first.pressSequentially("alpha")
+    await closeCard(page)
+
+    await openCard(page, "Second")
+    const second = page.getByPlaceholder("Notes")
+    await second.click()
+    await second.pressSequentially("beta")
+
+    await second.press(UNDO)
+    await expect(second).toHaveValue("")
+    // Nothing of the other card's session is reachable from here.
+    await second.press(UNDO)
+    await expect(second).toHaveValue("")
+    await closeCard(page)
+
+    await openCard(page, "First")
+    await expect(page.getByPlaceholder("Notes")).toHaveValue("alpha")
+  })
+
+  test("a native undo offered through beforeinput is refused", async ({
+    page,
+  }) => {
+    const notes = await openNotes(page)
+    await notes.pressSequentially("keep this")
+
+    // The Edit and context menus, and iOS shake-to-undo, reach the native stack
+    // without a keystroke the editor could intercept, so the refusal has to sit
+    // on the input itself.
+    const blocked = await notes.evaluate(
+      (el) =>
+        !el.dispatchEvent(
+          new InputEvent("beforeinput", {
+            inputType: "historyUndo",
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+    )
+
+    expect(blocked).toBe(true)
+    await expect(notes).toHaveValue("keep this")
+  })
+
+  // Chromium's legacy editing command goes around `beforeinput` and cannot be
+  // refused at all. What matters is that it stays harmless, which is browser
+  // behaviour worth pinning where it actually happens.
+  test.describe("the legacy editing command", () => {
+    test.skip(
+      ({ browserName }) => browserName !== "chromium",
+      "execCommand undo is a chromium path"
+    )
+
+    test("cannot leave the editor out of step with itself", async ({
+      page,
+    }) => {
+      const notes = await openNotes(page)
+      await notes.pressSequentially("keep this")
+
+      await notes.evaluate(() => document.execCommand("undo"))
+      // It got through, and took a character with it.
+      await expect(notes).toHaveValue("keep thi")
+
+      // But it arrived like any other edit, so the editor's own undo takes it
+      // straight back. Nothing is lost and the two never diverge.
+      await notes.press(UNDO)
+      await expect(notes).toHaveValue("keep this")
+    })
+  })
+
+  test.describe("IME composition", () => {
+    test.skip(
+      ({ browserName }) => browserName !== "chromium",
+      "composing through CDP is a chromium path"
+    )
+
+    test("a whole composition is one step", async ({ page }) => {
+      const notes = await openNotes(page)
+      await notes.pressSequentially("hi ")
+
+      // Compose and commit the way an IME does, rather than dispatching the
+      // composition events by hand.
+      const cdp = await page.context().newCDPSession(page)
+      await cdp.send("Input.imeSetComposition", {
+        text: "に",
+        selectionStart: 1,
+        selectionEnd: 1,
+      })
+      await cdp.send("Input.imeSetComposition", {
+        text: "にほん",
+        selectionStart: 3,
+        selectionEnd: 3,
+      })
+      await cdp.send("Input.insertText", { text: "日本" })
+      await expect(notes).toHaveValue("hi 日本")
+
+      // The states the IME passed through on the way are not steps of their own.
+      await notes.press(UNDO)
+      await expect(notes).toHaveValue("hi ")
+    })
+  })
+})
+
+test.describe("editor undo: the visible controls", () => {
+  const undoButton = (page: Page) =>
+    cardPanel(page).getByRole("button", { name: "Undo", exact: true })
+  const redoButton = (page: Page) =>
+    cardPanel(page).getByRole("button", { name: "Redo", exact: true })
+
+  test("both are dead until there is something to undo", async ({ page }) => {
+    await openNotes(page)
+
+    await expect(undoButton(page)).toBeDisabled()
+    await expect(redoButton(page)).toBeDisabled()
+  })
+
+  test("they drive the same stack as the shortcuts", async ({ page }) => {
+    const notes = await openNotes(page)
+    await notes.pressSequentially("hello world")
+
+    await expect(redoButton(page)).toBeDisabled()
+    await undoButton(page).click()
+    await expect(notes).toHaveValue("hello ")
+
+    await expect(redoButton(page)).toBeEnabled()
+    await redoButton(page).click()
+    await expect(notes).toHaveValue("hello world")
+
+    // The keyboard picks up where the pointer left off.
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("hello ")
+  })
+
+  test("undo reaches an edit made in the preview, where ⌘Z cannot", async ({
+    page,
+  }) => {
+    await createBoard(page)
+    await addCard(page, "To Do")
+    await retitleCard(page, "Untitled card", "Checklist")
+    await editCardBody(page, "Checklist", "- [ ] First\n- [ ] Second")
+
+    await card(page, "Checklist").click()
+    await cardPanel(page).getByRole("checkbox").first().click()
+    await expect(card(page, "Checklist")).toContainText("1/2")
+
+    // No textarea is mounted here, so the button is the only way back.
+    await undoButton(page).click()
+    await expect(card(page, "Checklist")).toContainText("0/2")
+  })
+
+  test.describe("on a phone", () => {
+    test.use({ viewport: { width: 390, height: 780 } })
+
+    test("undo moves into the card menu, where there is room", async ({
+      page,
+    }) => {
+      const notes = await openNotes(page)
+      await notes.pressSequentially("hello world")
+
+      // The header is already clipping the card's meta at this width.
+      await expect(undoButton(page)).toHaveCount(0)
+
+      await cardPanel(page)
+        .getByRole("button", { name: "Card actions" })
+        .click()
+      await page.getByRole("menuitem", { name: "Undo" }).click()
+
+      await expect(notes).toHaveValue("hello ")
+    })
+  })
+})
+
+test.describe("editor undo: against a synced board", () => {
+  test("a wikilink insert is one step", async ({ page }) => {
+    await signIn(page)
+    await createBoard(page)
+    await addCard(page, "To Do")
+    await retitleCard(page, "Untitled card", "Target card")
+    await addCard(page, "To Do")
+    await retitleCard(page, "Untitled card", "Source card")
+    const targetId = await cardDisplayId(page, "Target card")
+
+    await openCard(page, "Source card")
+    const notes = page.getByPlaceholder("Notes")
+    await notes.click()
+    await notes.pressSequentially("see [[Target")
+
+    await page.getByRole("button", { name: `Target card #${targetId}` }).click()
+    await expect(notes).toHaveValue(`see [[${targetId}|Target card]]`)
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("see [[Target")
+  })
+
+  test("a pasted attachment's markdown is one step", async ({ page }) => {
+    await signIn(page)
+    await createBoard(page)
+    await addCard(page, "To Do")
+    await card(page, "Untitled card").click()
+
+    const notes = page.getByPlaceholder("Notes")
+    await notes.click()
+    await notes.pressSequentially("shot: ")
+
+    await pasteInto(notes, await pngDataTransfer(page, "pasted.png"))
+    await expect(notes).toHaveValue(/!\[pasted\.png\]\(attachment:/)
+
+    await notes.press(UNDO)
+    await expect(notes).toHaveValue("shot: ")
+  })
+})


### PR DESCRIPTION
The card editor is a controlled textarea, so the browser's own undo stack was never dependable in it: it restores text React never hears about, and it knows nothing about the text the editor writes for you — a slash command's snippet, a continued list item, a pasted attachment's markdown. Pressing ⌘Z in a card could leave what is on screen and what is stored disagreeing, or simply do nothing useful. This gives each open card its own history instead.

## What it does

- **⌘Z / ⌘⇧Z** (Ctrl elsewhere) in the title and in the Notes field.
- Buttons in the card header, and in the card's "…" menu on a narrow screen, where the header has no room for them. The buttons are also the only way back from an edit made in the read-only preview — ticking a task box, say — which the keyboard shortcut cannot reach.
- One stack per open card, shared by title and body, so undo walks back through that card's edits newest-first whichever field they landed in.
- Each card has its own history; the controls are disabled when there is nothing to undo or redo, and editing after an undo drops the redo branch.

## How it works

A small dedicated history: `text-history.ts` holds the grouping as a pure function of the text, and `use-card-history.ts` binds it to the pane. Every path that changes a card's text already funnels through `CardPane.edit`, so the stack lives there and the editing paths themselves are untouched — typing, list continuation, cut line, pasted files, the slash and `[[` menus, and ticking a task box in the preview all feed it. `CardPane` is keyed by the card id, so a history cannot outlive its card or reach another one.

**Meaningful grouping.** Steps break on boundaries rather than on a timer: a run of word characters, with trailing whitespace absorbed into the word it follows, broken by a newline, a caret jump, a switch between inserting and deleting, or anything the app writes itself. The same automaton reads correctly backwards, so backspacing gives back the steps typing created. Elapsed time is only a fallback for a group left open. A step is therefore a function of the text and not of typing speed, which also means the tests never have to race a clock.

**Caret restoration.** The selection comes back with the text. It is read in a layout effect on the pane, which runs after the child hooks that own the textarea have applied their own caret, so an insertion's intended position is what gets recorded — mid-snippet included.

**Programmatic edits.** Anything the editor writes for you is a single step rather than a character-by-character replay: a slash command's snippet, a `[[` reference resolving to a link, a continued list item, a cut line, a pasted attachment's markdown. An IME composition is one step too, read from the element on `compositionend` because the final input event falls either side of it depending on the browser.

**Field-specific restoration.** A step restores only the fields it actually changed. Entries snapshot both title and body, but putting both back would roll back whatever had meanwhile arrived in the field the step never touched — a remote rename landing on the title while the body is being typed, which undo would otherwise revert and then save back over the incoming change.

**The native stack** is refused at `beforeinput`, covering the Edit menu, the context menu and iOS shake-to-undo, so the browser cannot restore text the app never hears about. Chromium's legacy editing command goes around that and cannot be refused, but it arrives as an ordinary edit and this history takes it straight back, so the two never diverge.

## Tests

- Unit tests for the grouping automaton (`text-history.test.ts`), exercising each boundary forwards and backwards.
- e2e for the editor (`card/undo-redo.spec.ts`): typing, the app's own edits, per-card scope, the native-stack refusal, and the visible controls including the narrow-screen menu.

## Not in scope

- **The native mobile app.** This is the web client's card editor; `apps/mobile` keeps its platform's own behavior.
- **History that survives closing a card.** The stack lives with the open card and is dropped when it closes. That is deliberate: a history kept across a reopen could offer to undo past edits that have since synced or changed elsewhere. Reopening a card starts fresh.
